### PR TITLE
Cleans orphaned icons + Code improvements

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,6 +26,7 @@ dependencies {
     implementation("com.drewnoakes:metadata-extractor:2.18.0")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.1")
     implementation("com.twelvemonkeys.imageio:imageio-jpeg:3.12.0")
+    implementation("org.apache.commons:commons-imaging:1.0.0-alpha5")
 }
 
 compose.desktop {

--- a/src/main/kotlin/dev/su386/calina/Calina.kt
+++ b/src/main/kotlin/dev/su386/calina/Calina.kt
@@ -59,12 +59,12 @@ fun main() {
     register(OnStartTask("Load config task", IO) { CalinaConfig.load(); CalinaConfig.save() })
     register(OnStartTask("Load Image Data", IO) {
         loadImageData()
-        println("Images loaded: ${images.size}\nBytes loaded: ${Calina.bytesLoaded}\nKB loaded: ${Calina.bytesLoaded.toLong()/1000.0/1000.0}")
+        println("Images loaded: ${images.size}\nBytes loaded: ${Calina.bytesLoaded}\nMB loaded: ${Calina.bytesLoaded.toLong()/1000.0/1000.0}")
         saveImageData()
         saveTags()
     })
     register(OnStartTask("Cleaning Icons") {
-        cleanOrphanedIcons().also { println("Orphans Deleted: ${it.first}, Orphan Space Liberated: ${it.second / 1000}MB") }
+        cleanOrphanedIcons().also { println("Orphans Deleted: ${it.first}, Orphan Space Liberated: ${it.second / 1000}KB") }
         images.values.forEach { it.cleanIconPath() }
     })
 

--- a/src/main/kotlin/dev/su386/calina/Calina.kt
+++ b/src/main/kotlin/dev/su386/calina/Calina.kt
@@ -14,6 +14,7 @@ import dev.su386.calina.app.App
 import dev.su386.calina.images.ImageManager.cleanMissingImages
 import dev.su386.calina.images.ImageManager.cleanOrphanedIcons
 import dev.su386.calina.images.ImageManager.cleanSingleImages
+import dev.su386.calina.images.ImageManager.cleanWrongImages
 import dev.su386.calina.images.ImageManager.images
 import dev.su386.calina.images.ImageManager.loadImageData
 import dev.su386.calina.images.ImageManager.readImageData
@@ -68,13 +69,11 @@ fun main() {
     })
 
     register(RepeatTask(
-        taskName = "Clean image file paths", taskCooldown = CalinaConfig.get<Long>("performance/imageHashTimeout") * 60L * 1000L,
+        taskName = "Clean image file paths", taskCooldown = 8 * 60L * 1000L,
         startImmediately = true,
     ) {
-        cleanMissingImages()
+        cleanMissingImages().also { it2 -> println("Missing image data deleted: $it2") }
         cleanSingleImages().also { it2 -> println("Single image data deleted: $it2") }
-        it.duration = CalinaConfig.get<Long>("performance/imageHashTimeout") * 60L * 1000L
-        println("Cleaned nonexistent images")
     })
     register(RepeatTask("Look for images", taskCooldown = CalinaConfig.get<Long>("performance/imageSearchTimeout") * 60L * 1000L) {
         println("Searching for images")
@@ -84,7 +83,10 @@ fun main() {
         saveImageData()
         println("Images loaded: ${images.size}\nBytes loaded: ${Calina.bytesLoaded}\nMB loaded: ${Calina.bytesLoaded.toLong()/1000.0/1000.0}")
     })
-
+    register(RepeatTask("Clean Wrong Images", taskCooldown = 5 * 60L * 1000L) {
+        cleanWrongImages().also { it2 -> println("Cleaned $it2 wrong images") }
+        it.duration = CalinaConfig.get<Long>("performance/imageHashTimeout") * 60L * 1000L
+    })
 
     register(OnCloseTask("Save config task", IO) { CalinaConfig.save() })
     register(OnCloseTask("Save Image Data", IO) { saveImageData(); saveTags() })

--- a/src/main/kotlin/dev/su386/calina/Calina.kt
+++ b/src/main/kotlin/dev/su386/calina/Calina.kt
@@ -59,12 +59,12 @@ fun main() {
     register(OnStartTask("Load config task", IO) { CalinaConfig.load(); CalinaConfig.save() })
     register(OnStartTask("Load Image Data", IO) {
         loadImageData()
-        println("Images loaded: ${images.size}\nBytes loaded: ${Calina.bytesLoaded}\nMB loaded: ${Calina.bytesLoaded.toLong()/1000.0/1000.0}")
+        println("Images loaded: ${images.size}\nBytes loaded: ${Calina.bytesLoaded}\nKB loaded: ${Calina.bytesLoaded.toLong()/1000.0/1000.0}")
         saveImageData()
         saveTags()
     })
     register(OnStartTask("Cleaning Icons") {
-        cleanOrphanedIcons()
+        cleanOrphanedIcons().also { println("Orphans Deleted: ${it.first}, Orphan Space Liberated: ${it.second / 1000}MB") }
         images.values.forEach { it.cleanIconPath() }
     })
 

--- a/src/main/kotlin/dev/su386/calina/Calina.kt
+++ b/src/main/kotlin/dev/su386/calina/Calina.kt
@@ -13,6 +13,7 @@ import dev.su386.calina.Calina.exitAppSafely
 import dev.su386.calina.app.App
 import dev.su386.calina.images.ImageManager.cleanMissingImages
 import dev.su386.calina.images.ImageManager.cleanOrphanedIcons
+import dev.su386.calina.images.ImageManager.cleanSingleImages
 import dev.su386.calina.images.ImageManager.images
 import dev.su386.calina.images.ImageManager.loadImageData
 import dev.su386.calina.images.ImageManager.readImageData
@@ -68,10 +69,10 @@ fun main() {
 
     register(RepeatTask(
         taskName = "Clean image file paths", taskCooldown = CalinaConfig.get<Long>("performance/imageHashTimeout") * 60L * 1000L,
-        startImmediately = false,
-        persistentCooldown = true
+        startImmediately = true,
     ) {
         cleanMissingImages()
+        cleanSingleImages().also { it2 -> println("Single image data deleted: $it2") }
         it.duration = CalinaConfig.get<Long>("performance/imageHashTimeout") * 60L * 1000L
         println("Cleaned nonexistent images")
     })

--- a/src/main/kotlin/dev/su386/calina/Calina.kt
+++ b/src/main/kotlin/dev/su386/calina/Calina.kt
@@ -62,8 +62,6 @@ fun main() {
         println("Images loaded: ${images.size}\nBytes loaded: ${Calina.bytesLoaded}\nMB loaded: ${Calina.bytesLoaded.toLong()/1000.0/1000.0}")
         saveImageData()
         saveTags()
-    })
-    register(OnStartTask("Cleaning Icons") {
         cleanOrphanedIcons().also { println("Orphans Deleted: ${it.first}, Orphan Space Liberated: ${it.second / 1000}KB") }
         images.values.forEach { it.cleanIconPath() }
     })

--- a/src/main/kotlin/dev/su386/calina/Calina.kt
+++ b/src/main/kotlin/dev/su386/calina/Calina.kt
@@ -12,6 +12,7 @@ import dev.su386.calina.Calina.applicationScope
 import dev.su386.calina.Calina.exitAppSafely
 import dev.su386.calina.app.App
 import dev.su386.calina.images.ImageManager.cleanMissingImages
+import dev.su386.calina.images.ImageManager.cleanOrphanedIcons
 import dev.su386.calina.images.ImageManager.images
 import dev.su386.calina.images.ImageManager.loadImageData
 import dev.su386.calina.images.ImageManager.readImageData
@@ -20,11 +21,9 @@ import dev.su386.calina.images.Tag.Companion.saveTags
 import dev.su386.calina.tasks.OnCloseTask
 import dev.su386.calina.tasks.OnStartTask
 import dev.su386.calina.tasks.RepeatTask
-import dev.su386.calina.tasks.RepeatTask.TaskCooldown.Companion.ms
 import dev.su386.calina.tasks.TaskManager
 import dev.su386.calina.tasks.TaskManager.onStart
 import dev.su386.calina.tasks.TaskManager.register
-import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers.IO
 import java.util.concurrent.atomic.AtomicLong
 import javax.imageio.ImageIO
@@ -64,6 +63,10 @@ fun main() {
         saveImageData()
         saveTags()
     })
+    register(OnStartTask("Cleaning Icons") {
+        cleanOrphanedIcons()
+        images.values.forEach { it.cleanIconPath() }
+    })
 
     register(RepeatTask(
         taskName = "Clean image file paths", taskCooldown = CalinaConfig.get<Long>("performance/imageHashTimeout") * 60L * 1000L,
@@ -82,6 +85,7 @@ fun main() {
         saveImageData()
         println("Images loaded: ${images.size}\nBytes loaded: ${Calina.bytesLoaded}\nMB loaded: ${Calina.bytesLoaded.toLong()/1000.0/1000.0}")
     })
+
 
     register(OnCloseTask("Save config task", IO) { CalinaConfig.save() })
     register(OnCloseTask("Save Image Data", IO) { saveImageData(); saveTags() })

--- a/src/main/kotlin/dev/su386/calina/CalinaConfig.kt
+++ b/src/main/kotlin/dev/su386/calina/CalinaConfig.kt
@@ -19,24 +19,17 @@ object CalinaConfig: Config("Settings", "") {
         )
         this["gallery"].name = "Gallery"
 
-        this["performance/imageHashCount"] = Integer(
-            name = "Image Hash Count",
-            description = "Paths for which to look for images",
-            1000
-        )
         this["performance/imageHashTimeout"] = Decimal(
-            name = "Image Hash Timeout (min)",
-            description = "",
-            10.0
+            name = "Image Hash Timeout (Days)",
+            description = "How often to check whether an image has a valid hash",
+            2.0
         )
         this["performance/imageSearchTimeout"] = Decimal(
             name = "Image Search Timeout (min)",
-            description = "",
+            description = "How often to search for new images",
             2.5
         )
         this["performance"].name = "Performance"
-
-
     }
 
     @Deprecated("Use load()", ReplaceWith("load()"))

--- a/src/main/kotlin/dev/su386/calina/data/Database.kt
+++ b/src/main/kotlin/dev/su386/calina/data/Database.kt
@@ -15,7 +15,7 @@ object Database {
     /**
      * @link https://docs.oracle.com/javase/tutorial/essential/environment/sysprop.html
      */
-    val PATH = "${System.getProperty("user.home")}/calina"
+    val PATH = "${System.getProperty("user.home")}/.calina"
     val JSON = GsonBuilder()
         .setExclusionStrategies(TransientExclusionStrategy())
         .setPrettyPrinting()

--- a/src/main/kotlin/dev/su386/calina/images/ImageData.kt
+++ b/src/main/kotlin/dev/su386/calina/images/ImageData.kt
@@ -6,25 +6,21 @@ import com.drew.metadata.exif.ExifSubIFDDirectory
 import com.drew.metadata.exif.GpsDirectory
 import dev.su386.calina.Calina
 import dev.su386.calina.data.Database
-import dev.su386.calina.images.ImageData.Companion.toImageData
-import dev.su386.calina.utils.FileUtils.safelyDelete
 import dev.su386.calina.utils.HashingImageInputStream
 import dev.su386.calina.utils.HashingInputStream
 import dev.su386.calina.utils.Location
-import kotlinx.coroutines.*
 import kotlinx.coroutines.Dispatchers.IO
+import kotlinx.coroutines.withContext
 import org.apache.commons.imaging.Imaging
 import java.awt.image.BufferedImage
 import java.io.File
 import java.io.FileInputStream
-import java.nio.MappedByteBuffer
 import java.nio.file.Files
 import java.nio.file.attribute.BasicFileAttributes
 import java.security.MessageDigest
 import java.util.*
 import javax.imageio.ImageIO
 import javax.imageio.ImageReadParam
-import javax.imageio.stream.ImageInputStream
 
 private const val COMPRESSED_IMAGE_SIZE = 240
 
@@ -37,6 +33,7 @@ class ImageData(
     vararg var filePaths: String
 ) {
     private var imageIconPath: String? = null
+    var timeSinceLastHashCheck: Long = 0L
     val imageSize: ImageSize get() {
         val cache = cachedImageSize
         if (cache != null) {
@@ -74,21 +71,17 @@ class ImageData(
                 }
 
                 // Ensure the entire stream is read
-                val buffer = ByteArray(64 * 1024)
-                while (hashingInputStream.read(buffer) != -1) {
-                    // Continue reading to the end to include all bytes in the hash
-                }
+                hashingInputStream.readTillEnd()
                 val hash = messageDigest.digest().joinToString("") { "%02x".format(it) }
                 // Compute the hash now that we've read all bytes
                 hashingInputStream.close()
 
                 if (this.hash == hash && image != null){
-//                    totalLoaded++
-                    return image
+                    return image.also { imageInputStream.close() }
                 }
             }
         } catch (e: Exception) {
-            println("Error loading icon for ${this.filePaths.firstOrNull()}: ${e.message}")
+            println("Error loading image for ${this.filePaths.firstOrNull()}: ${e.message}")
         }
 
         return BufferedImage(32, 32, BufferedImage.TYPE_INT_RGB)
@@ -197,24 +190,28 @@ class ImageData(
      *
      * @return The number of file paths removed
      */
-    suspend fun checkFileHashes(): Int = runBlocking<Int> {
-        val jobs = mutableListOf<Deferred<Unit>>()
-        val cleanedPaths = mutableListOf<String>()
-        val oldLength = this@ImageData.filePaths.size
-
-        this@ImageData.filePaths.forEach { path ->
-            jobs.add(async(IO) {
-                if (File(path).inputStream().parallelSHA256() == this@ImageData.hash) {
-                    cleanedPaths.add(path)
+    fun checkFileHashes(): Int {
+        val validPaths = mutableSetOf<String>()
+        this.filePaths
+            .forEach {
+                if (File(it).lastModified() < this.timeSinceLastHashCheck) {
+                    validPaths.add(it)
+                    return@forEach
                 }
-            })
-        }
 
-        jobs.awaitAll()
+                val digest = MessageDigest.getInstance("SHA-256")
+                val inputStream = HashingInputStream(FileInputStream(it), digest)
+                inputStream.readAllBytes()
+                inputStream.close()
+                val hash = digest.digest().joinToString("") { "%02x".format(it) }
+                if (hash == this.hash) {
+                    validPaths.add(it)
+                }
 
-        this@ImageData.filePaths = cleanedPaths.toTypedArray()
+                this.timeSinceLastHashCheck = System.currentTimeMillis()
+            }
 
-        return@runBlocking oldLength - this@ImageData.filePaths.size
+        return (this.filePaths.size - validPaths.size).also{ this.filePaths = validPaths.toTypedArray() }
     }
 
     override fun toString(): String {
@@ -222,40 +219,6 @@ class ImageData(
     }
 
     companion object {
-        /**
-         * Returns an SHA-256 hash of the byte array
-         */
-        suspend fun FileInputStream.parallelSHA256(): String {
-            val chunkSize = 4L * 1024L * 1024L // 4MB chunks
-            val digest = MessageDigest.getInstance("SHA-256")
-
-            return withContext(IO) {
-                val channel = this@parallelSHA256.channel
-                val fileSize = channel.size()
-
-                val results = (0 until fileSize step chunkSize).map { start ->
-                    async {
-                        val size = minOf(chunkSize, fileSize - start)
-                        val mappedBuffer: MappedByteBuffer = channel.map(
-                            java.nio.channels.FileChannel.MapMode.READ_ONLY,
-                            start,
-                            size
-                        )
-
-                        val buffer = ByteArray(mappedBuffer.remaining())
-                        mappedBuffer.get(buffer)
-                        buffer //Return the buffer.
-                    }
-                }.awaitAll()
-
-                results.forEach{buffer ->
-                    digest.update(buffer)
-                }
-
-                digest.digest().joinToString("") { "%02x".format(it) }
-            }
-        }
-
         /**
          * Returns the image data at that path.
          * If no metadata exists in an image, it returns a metadata with default values.
@@ -325,7 +288,8 @@ class ImageData(
                     cameraInfo = CameraInfo(cameraModel),
                     imageSize,
                     this@toImageData.path,
-                )
+                ).apply { this.timeSinceLastHashCheck = System.currentTimeMillis() }
+                    .also { input.close() }
             }
         }
     }

--- a/src/main/kotlin/dev/su386/calina/images/ImageData.kt
+++ b/src/main/kotlin/dev/su386/calina/images/ImageData.kt
@@ -76,7 +76,7 @@ class ImageData(
     }
 
     val icon: BufferedImage get() {
-        val path = imageIconPath ?: "${Database.PATH}/icons/$hash.png".also { imageIconPath = it }
+        val path = imageIconPath ?: "${Database.PATH}/icons/${hash}.png".also { imageIconPath = it }
         val iconFile = File(path).also { it.parentFile.mkdirs() }
         iconFile.setWritable(true)
         if (iconFile.exists()) {
@@ -133,7 +133,7 @@ class ImageData(
                 println("Error creating icon for ${this.filePaths.firstOrNull()}: ${e.message}")
             }
 
-            return image ?: BufferedImage(32, 32, BufferedImage.TYPE_INT_RGB)
+            return image ?: BufferedImage(imageSize.compressedImageSize.x, imageSize.compressedImageSize.y, BufferedImage.TYPE_INT_RGB)
         }
     }
 
@@ -173,7 +173,7 @@ class ImageData(
      */
     fun cleanIconPath(): Boolean {
         val file = File(imageIconPath ?: return false)
-        return file.exists().also {file.safelyDelete() }
+        return file.exists().also { if (!it) this.imageIconPath = null }
     }
 
 

--- a/src/main/kotlin/dev/su386/calina/images/ImageData.kt
+++ b/src/main/kotlin/dev/su386/calina/images/ImageData.kt
@@ -6,6 +6,7 @@ import com.drew.metadata.exif.ExifSubIFDDirectory
 import com.drew.metadata.exif.GpsDirectory
 import dev.su386.calina.Calina
 import dev.su386.calina.data.Database
+import dev.su386.calina.utils.FileUtils.safelyDelete
 import dev.su386.calina.utils.HashingImageInputStream
 import dev.su386.calina.utils.Location
 import kotlinx.coroutines.*
@@ -92,7 +93,7 @@ class ImageData(
                 return this.icon
             }
         } else {
-            var image = BufferedImage(32, 32, BufferedImage.TYPE_INT_RGB)
+            var image: BufferedImage? = null
             try {
                 for (file in filePaths){
                     // Create an input stream for the image file.
@@ -131,7 +132,8 @@ class ImageData(
             } catch (e: Exception) {
                 println("Error creating icon for ${this.filePaths.firstOrNull()}: ${e.message}")
             }
-            return image
+
+            return image ?: BufferedImage(32, 32, BufferedImage.TYPE_INT_RGB)
         }
     }
 
@@ -163,6 +165,18 @@ class ImageData(
         this.filePaths = this.filePaths.filter { path -> File(path).exists() }.toTypedArray()
         return oldLength - filePaths.size
     }
+
+    /**
+     * Checks whether the file in [imageIconPath] exists, and removes them if they do not
+     *
+     * @return true if a file was removed, else otherwise
+     */
+    fun cleanIconPath(): Boolean {
+        val file = File(imageIconPath ?: return false)
+        return file.exists().also {file.safelyDelete() }
+    }
+
+
 
     /**
      * Checks whether the file in [filePaths] refers to the same file, and removes them if they do not

--- a/src/main/kotlin/dev/su386/calina/images/ImageData.kt
+++ b/src/main/kotlin/dev/su386/calina/images/ImageData.kt
@@ -52,9 +52,7 @@ class ImageData(
         }
     }
     /**
-     * Returns the image associated with this image data.
-     *
-     * Caches the image for 30 seconds
+     * @return the BufferedImage associated with this image data.
      */
     val image: BufferedImage get() {
         try {
@@ -225,8 +223,7 @@ class ImageData(
 
     companion object {
         /**
-         * Returns the image data at that path.
-         * If no metadata exists in an image, it returns a metadata with default values.
+         * @return the image data at that path. If no metadata exists in an image, it returns a metadata with default values.
          *
          * Make sure to use Dispatchers.IO
          */

--- a/src/main/kotlin/dev/su386/calina/images/ImageData.kt
+++ b/src/main/kotlin/dev/su386/calina/images/ImageData.kt
@@ -177,7 +177,6 @@ class ImageData(
     }
 
 
-
     /**
      * Checks whether the file in [filePaths] refers to the same file, and removes them if they do not
      *

--- a/src/main/kotlin/dev/su386/calina/images/ImageData.kt
+++ b/src/main/kotlin/dev/su386/calina/images/ImageData.kt
@@ -5,6 +5,7 @@ import com.drew.metadata.exif.ExifIFD0Directory
 import com.drew.metadata.exif.ExifSubIFDDirectory
 import com.drew.metadata.exif.GpsDirectory
 import dev.su386.calina.Calina
+import dev.su386.calina.CalinaConfig
 import dev.su386.calina.data.Database
 import dev.su386.calina.utils.HashingImageInputStream
 import dev.su386.calina.utils.HashingInputStream
@@ -164,13 +165,17 @@ class ImageData(
     }
 
     /**
-     * Checks whether the file in [filePaths] exists, and removes them if they do not
+     * Checks whether the file in [filePaths] exists within the allowed paths, and removes them if they do not
      *
      * @return The number of file paths removed
      */
     fun cleanFilePaths(): Int {
         val oldLength = filePaths.size
-        this.filePaths = this.filePaths.filter { path -> File(path).exists() }.toTypedArray()
+        this.filePaths = this.filePaths.filter { path ->
+            File(path).exists() && CalinaConfig.get<List<String>>("gallery/imagePaths").any {
+                    folder ->  File(path).absolutePath.startsWith(File(folder).absolutePath)
+            }
+        }.toTypedArray()
         return oldLength - filePaths.size
     }
 

--- a/src/main/kotlin/dev/su386/calina/images/ImageData.kt
+++ b/src/main/kotlin/dev/su386/calina/images/ImageData.kt
@@ -6,11 +6,14 @@ import com.drew.metadata.exif.ExifSubIFDDirectory
 import com.drew.metadata.exif.GpsDirectory
 import dev.su386.calina.Calina
 import dev.su386.calina.data.Database
+import dev.su386.calina.images.ImageData.Companion.toImageData
 import dev.su386.calina.utils.FileUtils.safelyDelete
 import dev.su386.calina.utils.HashingImageInputStream
+import dev.su386.calina.utils.HashingInputStream
 import dev.su386.calina.utils.Location
 import kotlinx.coroutines.*
 import kotlinx.coroutines.Dispatchers.IO
+import org.apache.commons.imaging.Imaging
 import java.awt.image.BufferedImage
 import java.io.File
 import java.io.FileInputStream
@@ -21,6 +24,7 @@ import java.security.MessageDigest
 import java.util.*
 import javax.imageio.ImageIO
 import javax.imageio.ImageReadParam
+import javax.imageio.stream.ImageInputStream
 
 private const val COMPRESSED_IMAGE_SIZE = 240
 
@@ -29,11 +33,26 @@ class ImageData(
     val date: Long,
     val hash: String,
     val cameraInfo: CameraInfo,
-    val imageSize: ImageSize,
+    private var cachedImageSize: ImageSize?,
     vararg var filePaths: String
 ) {
     private var imageIconPath: String? = null
+    val imageSize: ImageSize get() {
+        val cache = cachedImageSize
+        if (cache != null) {
+            return cache
+        } else {
+            var imageSize: ImageSize? = null
+            try {
+                val im = Imaging.getImageSize(File(this.filePaths.firstOrNull()))
+                imageSize = ImageSize(im.width, im.height)
+            } catch (_: Exception) {
 
+            }
+
+            return imageSize.also { cachedImageSize = it } ?: ImageSize(32, 32)
+        }
+    }
     /**
      * Returns the image associated with this image data.
      *
@@ -104,13 +123,9 @@ class ImageData(
                     val reader = readers.next()
                     reader.input = imageInputStream
 
-                    // Get original dimensions.
-                    val originalWidth = reader.getWidth(0)
-                    val originalHeight = reader.getHeight(0)
-
                     // Calculate a subsampling factor (an integer >= 1).
                     var subsampling = 1
-                    while ((originalWidth / subsampling) > this.imageSize.compressedImageSize.x && (originalHeight / subsampling) > this.imageSize.compressedImageSize.y) {
+                    while ((imageSize.x / subsampling) > this.imageSize.compressedImageSize.x && (imageSize.y / subsampling) > this.imageSize.compressedImageSize.y) {
                         subsampling++
                     }
                     // If subsampling overshoots, step back one.
@@ -250,17 +265,13 @@ class ImageData(
         suspend fun File.toImageData(): ImageData = withContext(IO) {
             val messageDigest = MessageDigest.getInstance("SHA-256")
 
-            var imageSize = ImageSize(32, 32)
-            val imageInputStream = ImageIO.createImageInputStream(this@toImageData)
-            val hashingInputStream = HashingImageInputStream(imageInputStream, messageDigest)
+            val hashingInputStream = HashingInputStream(this@toImageData.inputStream().buffered(), messageDigest)
+            var imageSize: ImageSize? = null
+            try {
+                val im = Imaging.getImageSize(this@toImageData)
+                imageSize = ImageSize(im.width, im.height)
+            } catch (_: Exception) {
 
-            val imageReaders = ImageIO.getImageReaders(hashingInputStream)
-            if (imageReaders.hasNext()) {
-                val reader = imageReaders.next()
-                reader.setInput(hashingInputStream, true)
-
-                imageSize = ImageSize(reader.getWidth(reader.minIndex), reader.getHeight(reader.minIndex))
-                reader.dispose()
             }
 
             // Ensure the entire stream is read

--- a/src/main/kotlin/dev/su386/calina/images/ImageManager.kt
+++ b/src/main/kotlin/dev/su386/calina/images/ImageManager.kt
@@ -125,13 +125,14 @@ object ImageManager {
      *
      * @return the numbers of orphans deleted
      */
-    fun cleanOrphanedIcons(): Int {
+    fun cleanOrphanedIcons(): Pair<Int, Long> {
         var orphanedIcons = 0
+        var orphanedIconSpace = 0L
         val iconPath = File("${Database.PATH}/icons/")
         iconPath.walk()
             .filter { !images.containsKey(it.nameWithoutExtension) }
-            .forEach { it.safelyDelete(); orphanedIcons++ }
-        return orphanedIcons
+            .forEach { it.safelyDelete().also { deleted -> if (deleted) orphanedIcons++; orphanedIconSpace += it.length() } }
+        return Pair(orphanedIcons, orphanedIconSpace)
     }
 
     /**

--- a/src/main/kotlin/dev/su386/calina/images/ImageManager.kt
+++ b/src/main/kotlin/dev/su386/calina/images/ImageManager.kt
@@ -1,10 +1,12 @@
 package dev.su386.calina.images
 
+import dev.su386.calina.data.Database
 import dev.su386.calina.data.Database.readData
 import dev.su386.calina.data.Database.writeData
 import dev.su386.calina.images.ImageData.Companion.toImageData
 import dev.su386.calina.images.filters.Filter
 import dev.su386.calina.images.filters.FilterJunction.Companion.toDisJunction
+import dev.su386.calina.utils.FileUtils.safelyDelete
 import kotlinx.coroutines.*
 import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.flow.asFlow
@@ -116,6 +118,20 @@ object ImageManager {
         images.forEach { (_, imageData) ->
             imageData.cleanFilePaths()
         }
+    }
+
+    /**
+     * Cleans all icons in the icon folder that do not have an image referencing it
+     *
+     * @return the numbers of orphans deleted
+     */
+    fun cleanOrphanedIcons(): Int {
+        var orphanedIcons = 0
+        val iconPath = File("${Database.PATH}/icons/")
+        iconPath.walk()
+            .filter { !images.containsKey(it.nameWithoutExtension) }
+            .forEach { it.safelyDelete(); orphanedIcons++ }
+        return orphanedIcons
     }
 
     /**

--- a/src/main/kotlin/dev/su386/calina/images/ImageManager.kt
+++ b/src/main/kotlin/dev/su386/calina/images/ImageManager.kt
@@ -141,7 +141,7 @@ object ImageManager {
         var orphanedIconSpace = 0L
         val iconPath = File("${Database.PATH}/icons/")
         iconPath.walk()
-            .filter { !images.containsKey(it.nameWithoutExtension) }
+            .filter { !images.containsKey(it.nameWithoutExtension) || it.length() == 0L}
             .forEach { it.safelyDelete().also { deleted -> if (deleted) orphanedIcons++; orphanedIconSpace += it.length() } }
         return Pair(orphanedIcons, orphanedIconSpace)
     }

--- a/src/main/kotlin/dev/su386/calina/images/ImageManager.kt
+++ b/src/main/kotlin/dev/su386/calina/images/ImageManager.kt
@@ -1,5 +1,6 @@
 package dev.su386.calina.images
 
+import dev.su386.calina.CalinaConfig
 import dev.su386.calina.data.Database
 import dev.su386.calina.data.Database.readData
 import dev.su386.calina.data.Database.writeData
@@ -114,10 +115,12 @@ object ImageManager {
     /**
      * Removes all images whose paths do not exist
      */
-    fun cleanMissingImages() {
+    fun cleanMissingImages(): Int {
+        var i = 0
         images.forEach { (_, imageData) ->
-            imageData.cleanFilePaths()
+            i += imageData.cleanFilePaths()
         }
+        return i
     }
 
     /**
@@ -151,14 +154,20 @@ object ImageManager {
      *
      * @param n - Takes the first [n] images
      */
-    fun cleanWrongImages(n: Int = images.size) = runBlocking(IO) {
-        val jobs = mutableListOf<Deferred<Unit>>()
+    fun cleanWrongImages(n: Int = images.size) = runBlocking (IO) {
+        val jobs = mutableListOf<Deferred<Int>>()
+        images.values
+            .filter { it.timeSinceLastHashCheck < System.currentTimeMillis() - 1000 * 60 * 60 * 24 * CalinaConfig.get<Double>("performance/imageHashTimeout") }
+            .sortedBy { it.timeSinceLastHashCheck }.take(n)
+            .forEach {
+                jobs.add(
+                    async(IO) {
+                        it.checkFileHashes()
+                    }
+                )
+            }
 
-        images.values.take(n).forEach {
-            jobs.add(async(IO) { it.cleanFilePaths(); return@async })
-        }
-
-        jobs.awaitAll()
+        jobs.awaitAll().sum()
     }
 
     fun getImagesByDate(filters: List<Filter> = listOf()): List<List<ImageData>> {

--- a/src/main/kotlin/dev/su386/calina/images/ImageManager.kt
+++ b/src/main/kotlin/dev/su386/calina/images/ImageManager.kt
@@ -121,6 +121,17 @@ object ImageManager {
     }
 
     /**
+     * Returns the total number of images removed
+     */
+    fun cleanSingleImages(): Int {
+        return images.filter { (_, imageData) ->
+            imageData.filePaths.isEmpty()
+        }.onEach { (key, _) ->
+            images.remove(key)
+        }.count()
+    }
+
+    /**
      * Cleans all icons in the icon folder that do not have an image referencing it
      *
      * @return the numbers of orphans deleted

--- a/src/main/kotlin/dev/su386/calina/images/ImageManager.kt
+++ b/src/main/kotlin/dev/su386/calina/images/ImageManager.kt
@@ -124,7 +124,9 @@ object ImageManager {
     }
 
     /**
-     * Returns the total number of images removed
+     * Remove imagedata objects that have no file paths attached to them
+     *
+     * @return the total number of imagedata objects removed
      */
     fun cleanSingleImages(): Int {
         return images.filter { (_, imageData) ->

--- a/src/main/kotlin/dev/su386/calina/tasks/RepeatTask.kt
+++ b/src/main/kotlin/dev/su386/calina/tasks/RepeatTask.kt
@@ -12,7 +12,6 @@ import java.util.*
  *
  * @param taskName - Name of the task
  * @param taskCooldown - Time in ms between the executing of each task
- * @param persistentCooldown - Whether the cooldown time is saved on restarts. If true, and an app is restarted, the time since last active will save
  * @param startImmediately - Whether the scheduled task should run the first time immediately or wait the cooldown
  * @param coroutineDispatcher - Dispatcher context to run the [onRun] function in
  * @param onRun - What to run when the task is called

--- a/src/main/kotlin/dev/su386/calina/tasks/ScheduledTask.kt
+++ b/src/main/kotlin/dev/su386/calina/tasks/ScheduledTask.kt
@@ -12,7 +12,6 @@ import java.util.*
  *
  * @param taskName - Name of the task
  * @param runIn - Time in ms for when to execute the task
- * @param persistentTimer - Whether the scheduled task is saved on restarts. If true, and an app is restarted, the time since last active will save
  * @param coroutineDispatcher - Dispatcher context to run the [onRun] function in
  * @param onRun - What to run when the task is called
  */

--- a/src/main/kotlin/dev/su386/calina/utils/FileUtils.kt
+++ b/src/main/kotlin/dev/su386/calina/utils/FileUtils.kt
@@ -1,0 +1,12 @@
+package dev.su386.calina.utils
+
+import java.io.File
+
+object FileUtils {
+    /**
+     * Deletes the path the file without causing an error
+     *
+     * @return true if a file exists and was deleted
+     */
+    fun File.safelyDelete(): Boolean = this.exists().also { this.deleteOnExit(); this.setWritable(true).also{ if (it) this.delete() } }
+}

--- a/src/main/kotlin/dev/su386/calina/utils/FileUtils.kt
+++ b/src/main/kotlin/dev/su386/calina/utils/FileUtils.kt
@@ -4,9 +4,9 @@ import java.io.File
 
 object FileUtils {
     /**
-     * Deletes the path the file without causing an error
+     * Deletes the file without causing an error
      *
-     * @return true if a file exists and was deleted
+     * @return true if a file exists
      */
     fun File.safelyDelete(): Boolean = this.exists().also { this.deleteOnExit(); this.setWritable(true).also{ if (it) this.delete() } }
 }

--- a/src/main/kotlin/dev/su386/calina/utils/HashingImageInputStream.kt
+++ b/src/main/kotlin/dev/su386/calina/utils/HashingImageInputStream.kt
@@ -12,6 +12,11 @@ class HashingImageInputStream(
 
     private var streamPosition: Long = 0
 
+    fun readTillEnd() {
+        while (this.read(ByteArray(64 * 1024)) != -1) {
+        }
+    }
+
     override fun read(): Int {
         val byteRead = inputStream.read()
         if (byteRead != -1) {

--- a/src/main/kotlin/dev/su386/calina/utils/HashingInputStream.kt
+++ b/src/main/kotlin/dev/su386/calina/utils/HashingInputStream.kt
@@ -11,6 +11,11 @@ class HashingInputStream(
 
     private var streamPosition: Long = 0
 
+    fun readTillEnd() {
+        while (this.read(ByteArray(64 * 1024)) != -1) {
+        }
+    }
+
     override fun read(): Int {
         val byteRead = inputStream.read()
         if (byteRead != -1) {


### PR DESCRIPTION
# Requires #21

- Cleans orphaned icons
   - Icons that no longer have an image pointing to them, and icons that are 0kb will be deleted
- Clean orphaned images
  - Image data that no longer has any valid image paths will be deleted
- Changed the data storage path from ``$home/calina`` -> ``$home/.calina`` 
- Validate whether files located at the file paths are correct